### PR TITLE
fix: updates the docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   credential_digger:
     build:


### PR DESCRIPTION
updates the docker-compose.yml to fix the warning "credential-digger/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"